### PR TITLE
Add csv output option

### DIFF
--- a/BackupPC_report
+++ b/BackupPC_report
@@ -25,10 +25,10 @@ $ENV{PATH} = '/usr/bin';
 
 our ( $opt_a, $opt_f, $opt_s, $opt_w, $opt_help, $opt_man );
 $opt_f = "report";
-GetOptions( "a", "f=s" => "report", "s", "w=f", "help|?", "man" ) || pod2usage(2);
+GetOptions( "a", "f=s" => \$opt_f, "s", "w=f", "help|?", "man" ) || pod2usage(2);
 pod2usage( -exitstatus => 0, -verbose => 2 ) if $opt_man;
 pod2usage(1) if $opt_help;
-pod2usage( -msg => "Unsupported value for -f", -exitstatus => 2 ) if $opt_f !~ /(report|csv)/i;
+pod2usage( -msg => "Unsupported value for -f", -exitstatus => 2 ) if $opt_f !~ /^(report|csv)$/i;
 
 # Set backuppc UID/GID
 my ( undef, undef, $bpcUID, $bpcGID ) = getpwnam($bpcUser);
@@ -161,7 +161,19 @@ for my $host ( @ARGV ? @ARGV : @hosts ) {
 # Supress report if no warnings
 !$opt_s || $warnOutdated || $warnErr || $warnActive || $warnPartial || exit 0;
 
-if ( $opt_f =~ /report/i ) {
+if ( $opt_f =~ /^csv$/i ) {
+
+    # csv header
+    printf
+      "%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s\n",
+      "warn_flags", "backup_number", "host_name", "date_time", "size_mb",
+      "lvl", "duratation_min", "xfer_err", "share_err", "file_err", "tar_err",
+      "age_days";
+
+    # csv content
+    map { printf "%s,%d,%s,%s,%s,%d,%s%s,%s,%s,%s,%s,%d\n", @$_; } @Report;
+}
+else {
 
     # Print report header
     print POSIX::strftime( '%Y-%m-%d %H:%M', localtime(time) ), "       ",
@@ -187,18 +199,6 @@ if ( $opt_f =~ /report/i ) {
 
     # Print the rest of the table
     map { printf "%4s [%4d] %-${hostColWidth}s %-16s %6s %3d %1s%5s | %4s %5s %4s %3s | %6d\n", @$_; } @Report;
-}
-elsif ( $opt_f =~ /csv/i ) {
-
-    # csv header
-    printf
-      "%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s\n",
-      "warn_flags", "backup_number", "host_name", "date_time", "size_mb",
-      "lvl", "duratation_min", "xfer_err", "share_err", "file_err", "tar_err",
-      "age_days";
-
-    # csv content
-    map { printf "%s,%d,%s,%s,%s,%d,%s%s,%s,%s,%s,%s,%d\n", @$_; } @Report;
 }
 
 __END__

--- a/BackupPC_report
+++ b/BackupPC_report
@@ -25,7 +25,7 @@ $ENV{PATH} = '/usr/bin';
 
 our ( $opt_a, $opt_f, $opt_s, $opt_w, $opt_help, $opt_man );
 $opt_f = "report";
-GetOptions( "a", "f=s" => \$opt_f, "s", "w=f", "help|?", "man" ) || pod2usage(2);
+GetOptions( "a", "f=s", "s", "w=f", "help|?", "man" ) || pod2usage(2);
 pod2usage( -exitstatus => 0, -verbose => 2 ) if $opt_man;
 pod2usage(1) if $opt_help;
 pod2usage( -msg => "Unsupported value for -f", -exitstatus => 2 ) if $opt_f !~ /^(report|csv)$/i;

--- a/BackupPC_report
+++ b/BackupPC_report
@@ -28,7 +28,7 @@ $opt_f = "report";
 GetOptions( "a", "f=s" => "report", "s", "w=f", "help|?", "man" ) || pod2usage(2);
 pod2usage( -exitstatus => 0, -verbose => 2 ) if $opt_man;
 pod2usage(1) if $opt_help;
-pod2usage( -msg => "Unsupported value for -f", -exitstatus => 2) if  $opt_f !~ /(report|csv)/i;
+pod2usage( -msg => "Unsupported value for -f", -exitstatus => 2 ) if $opt_f !~ /(report|csv)/i;
 
 # Set backuppc UID/GID
 my ( undef, undef, $bpcUID, $bpcGID ) = getpwnam($bpcUser);
@@ -161,41 +161,44 @@ for my $host ( @ARGV ? @ARGV : @hosts ) {
 # Supress report if no warnings
 !$opt_s || $warnOutdated || $warnErr || $warnActive || $warnPartial || exit 0;
 
-if ($opt_f =~ /report/i) {
-  # Print report header
-  print POSIX::strftime( '%Y-%m-%d %H:%M', localtime(time) ), "       ",
-    scalar @hosts, " host(s) configured ($hostsDisabled disabled)\n\n";
-  print "*WARNING* Some backups with ERRORs!", "\n\n" if $warnErr;
-  print "*WARNING* Most recent backups for some hosts are older than expected!", "\n\n"
-    if $warnOutdated;
-  print "*WARNING* There are in-progress backups!", "\n\n" if $warnActive;
-  print "*WARNING* There are partial backups!",     "\n\n" if $warnPartial;
+if ( $opt_f =~ /report/i ) {
 
-  # Print BackupPC URL
-  printf "\nURL: $bpc->{Conf}{CgiURL}\n\n";
+    # Print report header
+    print POSIX::strftime( '%Y-%m-%d %H:%M', localtime(time) ), "       ",
+      scalar @hosts, " host(s) configured ($hostsDisabled disabled)\n\n";
+    print "*WARNING* Some backups with ERRORs!",                                   "\n\n" if $warnErr;
+    print "*WARNING* Most recent backups for some hosts are older than expected!", "\n\n"
+      if $warnOutdated;
+    print "*WARNING* There are in-progress backups!", "\n\n" if $warnActive;
+    print "*WARNING* There are partial backups!",     "\n\n" if $warnPartial;
 
-  # Print table header
-  printf "%4s %6s %-${hostColWidth}s %-16s %6s %3s %6s | %4s %5s %4s %3s | %6s\n",
-    "warn", "backup", "host name", "date/time", "size", "", "durat.",
-    "xfer", "Share", "File", "tar", "age";
-  printf
-    "%4s %6s %-${hostColWidth}s %-16s %6s %3s %6s | %-4s %-5s %-4s %3s | %6s\n",
-    "flag", "number", "", "", "(MB)", "lvl", "(min)",
-    "Err", "Err", "Err", "Err", "(days)";
-  print "-" x ( $hostColWidth + 78 ), "\n";
+    # Print BackupPC URL
+    printf "\nURL: $bpc->{Conf}{CgiURL}\n\n";
 
-  # Print the rest of the table
-  map { printf "%4s [%4d] %-${hostColWidth}s %-16s %6s %3d %1s%5s | %4s %5s %4s %3s | %6d\n", @$_; } @Report
+    # Print table header
+    printf "%4s %6s %-${hostColWidth}s %-16s %6s %3s %6s | %4s %5s %4s %3s | %6s\n",
+      "warn", "backup", "host name", "date/time", "size", "", "durat.",
+      "xfer", "Share", "File", "tar", "age";
+    printf
+      "%4s %6s %-${hostColWidth}s %-16s %6s %3s %6s | %-4s %-5s %-4s %3s | %6s\n",
+      "flag", "number", "", "", "(MB)", "lvl", "(min)",
+      "Err", "Err", "Err", "Err", "(days)";
+    print "-" x ( $hostColWidth + 78 ), "\n";
+
+    # Print the rest of the table
+    map { printf "%4s [%4d] %-${hostColWidth}s %-16s %6s %3d %1s%5s | %4s %5s %4s %3s | %6d\n", @$_; } @Report;
 }
-elsif ($opt_f =~ /csv/i) {
-  # csv header
-  printf
+elsif ( $opt_f =~ /csv/i ) {
+
+    # csv header
+    printf
       "%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s\n",
-      "warn_flags","backup_number", "host_name", "date_time", "size_mb",
+      "warn_flags", "backup_number", "host_name", "date_time", "size_mb",
       "lvl", "duratation_min", "xfer_err", "share_err", "file_err", "tar_err",
       "age_days";
-  # csv content
-  map { printf "%s,%d,%s,%s,%s,%d,%s%s,%s,%s,%s,%s,%d\n", @$_; } @Report;
+
+    # csv content
+    map { printf "%s,%d,%s,%s,%s,%d,%s%s,%s,%s,%s,%s,%d\n", @$_; } @Report;
 }
 
 __END__
@@ -264,9 +267,9 @@ Include all available backups in the report. The default is the most recent back
 
 =item  B<-f> I<format>
 
-Outputs the report in the given I<format>. Possible values are "report" and "csv".
-The default is "report" printing the report with additional header lines. "csv" will print the backup information table
-in a more machine readable CSV format.
+Outputs the report in the given I<format>. Possible values are "report" and "csv". The default is "report" printing the
+report with additional header lines. "csv" will print the backup information table in a more machine readable CSV
+format.
 
 =item  B<-s>
 

--- a/BackupPC_report
+++ b/BackupPC_report
@@ -9,8 +9,6 @@
 use strict;
 use warnings;                # global flag -w produces warnings from BackupPC::Lib
 use lib '/usr/local/lib';    # <<< change path prefix to match your installation
-use lib '/usr/share/backuppc/lib';             # <<<< REMOVE THIS BEFORE RELEASE
-use lib './lib';             # <<<< REMOVE THIS BEFORE RELEASE
 use BackupPC::Lib;
 use POSIX qw( getuid getgid setuid setgid floor );
 use Getopt::Long;

--- a/BackupPC_report
+++ b/BackupPC_report
@@ -9,6 +9,8 @@
 use strict;
 use warnings;                # global flag -w produces warnings from BackupPC::Lib
 use lib '/usr/local/lib';    # <<< change path prefix to match your installation
+use lib '/usr/share/backuppc/lib';             # <<<< REMOVE THIS BEFORE RELEASE
+use lib './lib';             # <<<< REMOVE THIS BEFORE RELEASE
 use BackupPC::Lib;
 use POSIX qw( getuid getgid setuid setgid floor );
 use Getopt::Long;
@@ -23,10 +25,12 @@ my $bpcUser = 'backuppc';
 delete @ENV{qw(IFS CDPATH ENV BASH_ENV)};
 $ENV{PATH} = '/usr/bin';
 
-our ( $opt_a, $opt_s, $opt_w, $opt_help, $opt_man );
-GetOptions( "a", "s", "w=f", "help|?", "man" ) || pod2usage(2);
+our ( $opt_a, $opt_f, $opt_s, $opt_w, $opt_help, $opt_man );
+$opt_f = "report";
+GetOptions( "a", "f=s" => "report", "s", "w=f", "help|?", "man" ) || pod2usage(2);
 pod2usage( -exitstatus => 0, -verbose => 2 ) if $opt_man;
 pod2usage(1) if $opt_help;
+pod2usage( -msg => "Unsupported value for -f", -exitstatus => 2) if  $opt_f !~ /(report|csv)/i;
 
 # Set backuppc UID/GID
 my ( undef, undef, $bpcUID, $bpcGID ) = getpwnam($bpcUser);
@@ -159,30 +163,42 @@ for my $host ( @ARGV ? @ARGV : @hosts ) {
 # Supress report if no warnings
 !$opt_s || $warnOutdated || $warnErr || $warnActive || $warnPartial || exit 0;
 
-# Print report header
-print POSIX::strftime( '%Y-%m-%d %H:%M', localtime(time) ), "       ",
-  scalar @hosts, " host(s) configured ($hostsDisabled disabled)\n\n";
-print "*WARNING* Some backups with ERRORs!", "\n\n" if $warnErr;
-print "*WARNING* Most recent backups for some hosts are older than expected!", "\n\n"
-  if $warnOutdated;
-print "*WARNING* There are in-progress backups!", "\n\n" if $warnActive;
-print "*WARNING* There are partial backups!",     "\n\n" if $warnPartial;
+if ($opt_f =~ /report/i) {
+  # Print report header
+  print POSIX::strftime( '%Y-%m-%d %H:%M', localtime(time) ), "       ",
+    scalar @hosts, " host(s) configured ($hostsDisabled disabled)\n\n";
+  print "*WARNING* Some backups with ERRORs!", "\n\n" if $warnErr;
+  print "*WARNING* Most recent backups for some hosts are older than expected!", "\n\n"
+    if $warnOutdated;
+  print "*WARNING* There are in-progress backups!", "\n\n" if $warnActive;
+  print "*WARNING* There are partial backups!",     "\n\n" if $warnPartial;
 
-# Print BackupPC URL
-printf "\nURL: $bpc->{Conf}{CgiURL}\n\n";
+  # Print BackupPC URL
+  printf "\nURL: $bpc->{Conf}{CgiURL}\n\n";
 
-# Print table header
-printf "%4s %6s %-${hostColWidth}s %-16s %6s %3s %6s | %4s %5s %4s %3s | %6s\n",
-  "warn", "backup", "host name", "date/time", "size", "", "durat.",
-  "xfer", "Share", "File", "tar", "age";
-printf
-  "%4s %6s %-${hostColWidth}s %-16s %6s %3s %6s | %-4s %-5s %-4s %3s | %6s\n",
-  "flag", "number", "", "", "(MB)", "lvl", "(min)",
-  "Err", "Err", "Err", "Err", "(days)";
-print "-" x ( $hostColWidth + 78 ), "\n";
+  # Print table header
+  printf "%4s %6s %-${hostColWidth}s %-16s %6s %3s %6s | %4s %5s %4s %3s | %6s\n",
+    "warn", "backup", "host name", "date/time", "size", "", "durat.",
+    "xfer", "Share", "File", "tar", "age";
+  printf
+    "%4s %6s %-${hostColWidth}s %-16s %6s %3s %6s | %-4s %-5s %-4s %3s | %6s\n",
+    "flag", "number", "", "", "(MB)", "lvl", "(min)",
+    "Err", "Err", "Err", "Err", "(days)";
+  print "-" x ( $hostColWidth + 78 ), "\n";
 
-# Print the rest of the table
-map { printf "%4s [%4d] %-${hostColWidth}s %-16s %6s %3d %1s%5s | %4s %5s %4s %3s | %6d\n", @$_; } @Report
+  # Print the rest of the table
+  map { printf "%4s [%4d] %-${hostColWidth}s %-16s %6s %3d %1s%5s | %4s %5s %4s %3s | %6d\n", @$_; } @Report
+}
+elsif ($opt_f =~ /csv/i) {
+  # csv header
+  printf
+      "%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s\n",
+      "warn_flags","backup_number", "host_name", "date_time", "size_mb",
+      "lvl", "duratation_min", "xfer_err", "share_err", "file_err", "tar_err",
+      "age_days";
+  # csv content
+  map { printf "%s,%d,%s,%s,%s,%d,%s%s,%s,%s,%s,%s,%d\n", @$_; } @Report;
+}
 
 __END__
 
@@ -247,6 +263,12 @@ Note: any reports not include archive hosts.
 =item  B<-a>
 
 Include all available backups in the report. The default is the most recent backups only.
+
+=item  B<-f> I<format>
+
+Outputs the report in the given I<format>. Possible values are "report" and "csv".
+The default is "report" printing the report with additional header lines. "csv" will print the backup information table
+in a more machine readable CSV format.
 
 =item  B<-s>
 


### PR DESCRIPTION
Hello Alexander,

I'm currently working on a monitoring check using your reporting tool. For easier parsing of the reports output I want to introduce a new  `-f`switch supporting the report output as CSV. This will make the report much easier to process by machines. 

```
./BackupPC_report -f csv 
warn_flags,backup_number,host_name,date_time,size_mb,lvl,duratation_min,xfer_err,share_err,file_err,tar_err,age_days
,203,host1,2019-08-12 01:01,3504,1,1,0,0,0,0,0
,209,host2,2019-08-12 01:01,4885,1,3,0,0,0,0,0
E,141,host3,2019-08-12 01:04,11190,1,6,2,0,0,2,0
ED,73,host4,2019-08-12 17:41,86934,1,11,3,0,0,3,0
``` 

Not submitting `-f csv` will keep the current behaviour and print the full formatted report. 